### PR TITLE
Update android api to android-24

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ LABEL version="1.1.0"
 ENV ANDROID_SDK_FILE android-sdk_r24.4.1-linux.tgz
 ENV ANDROID_SDK_URL https://dl.google.com/android/${ANDROID_SDK_FILE}
 ENV ANDROID_BUILD_TOOLS_VERSION 24.0.1
-ENV ANDROID_APIS android-21
+ENV ANDROID_APIS android-21,android-24
 ENV ANDROID_ABI sys-img-armeabi-v7a-android-21,sys-img-armeabi-v7a-android-21
 ENV ANDROID_EXTRA extra-android-m2repository
 


### PR DESCRIPTION
To solve:
`failed to find target with hash string 'android-24' in: /opt/android-sdk-linux`
I had to add android-24 in to our supported platforms with:
`android update sdk -a -u -t platform-tools, android-24`
